### PR TITLE
[common] 권한 체크 어노테이션 구현

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 }

--- a/common/src/main/java/com/common/aop/AuthCheckAspect.java
+++ b/common/src/main/java/com/common/aop/AuthCheckAspect.java
@@ -1,0 +1,40 @@
+package com.common.aop;
+
+import com.common.aop.annotation.AuthCheck;
+import com.common.exception.CustomException;
+import com.common.exception.type.ApiErrorCode;
+import com.common.resolver.dto.CurrentUserInfoDto;
+import com.common.resolver.dto.UserRole;
+import java.util.Arrays;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j(topic="AUTH CHECK::")
+public class AuthCheckAspect {
+
+  @Before("@annotation(authCheck)")
+  public void authCheck(JoinPoint joinPoint, AuthCheck authCheck) throws Throwable {
+
+    Set<UserRole> roles = Set.of(authCheck.roles());
+    CurrentUserInfoDto userInfoDto = getCurrentUserInfoDto(joinPoint.getArgs());
+    log.debug("유저 아이디: {}, 유저 권한: {} - 필요 권한: {}", userInfoDto.userId(), userInfoDto.role(), roles);
+
+    if (!roles.contains(userInfoDto.role())) {
+      throw CustomException.from(ApiErrorCode.FORBIDDEN);
+    }
+  }
+
+  private CurrentUserInfoDto getCurrentUserInfoDto(Object[] args) {
+    return Arrays.stream(args)
+        .filter(arg -> arg instanceof CurrentUserInfoDto && arg != null)
+        .map(CurrentUserInfoDto.class::cast)
+        .findFirst()
+        .orElseThrow(() -> CustomException.from(ApiErrorCode.UNAUTHORIZED));
+  }
+}

--- a/common/src/main/java/com/common/aop/annotation/AuthCheck.java
+++ b/common/src/main/java/com/common/aop/annotation/AuthCheck.java
@@ -1,0 +1,14 @@
+package com.common.aop.annotation;
+
+import com.common.resolver.dto.UserRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AuthCheck {
+  UserRole[] roles()
+      default {UserRole.ROLE_MASTER, UserRole.ROLE_HUB, UserRole.ROLE_DELIVERY, UserRole.ROLE_COMPANY};
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #31

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 권한 체크 어노테이션 구현


## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
```
@AuthCheck(roles = {UserRole.ROLE_MASTER, UserRole.ROLE_COMPANY})
```
![image](https://github.com/user-attachments/assets/10a05bd2-385d-4452-8cc4-1403777c0045)

- 위 이미지와 같이 권한이 필요한 메서드 위에 해당 어노테이션을 등록해서 활용해주시면 됩니다.
- 사용자가 어노테이션에 **등록한 권한(roles) 중 하나의 권한을 가지고 있는 경우 정상 동작하고, 그렇지 않은 경우 익셉션(401, 403**)이 발생합니다.
- roles 값을 따로 설정하지 않고 디폴트로 사용하게 되면, 모든 권한(마스터, 허브 관리자, 배송 관리자, 업체 관리자) 중 하나의 권한을 갖고 있는지 검토합니다. 