### PR TITLE
[common] 페이지네이션 관련 공통 코드 추가

### DIFF
--- a/common/src/main/java/com/common/config/WebConfig.java
+++ b/common/src/main/java/com/common/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.common.config;
 
 import com.common.resolver.CurrentUserInfoResolver;
+import com.common.resolver.CustomPageableArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -12,9 +13,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
   private final CurrentUserInfoResolver currentUserInfoResolver;
+  private final CustomPageableArgumentResolver customPageableArgumentResolver;
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
     resolvers.add(currentUserInfoResolver);
+    resolvers.add(customPageableArgumentResolver);
   }
 }

--- a/common/src/main/java/com/common/resolver/CustomPageableArgumentResolver.java
+++ b/common/src/main/java/com/common/resolver/CustomPageableArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.common.resolver;
+
+import java.util.Set;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+  private static final Set<Integer> ALLOWED_PAGE_SIZES = Set.of(10, 30, 50);
+  private static final int DEFAULT_PAGE_SIZE = 10;
+
+  @Override
+  public Pageable resolveArgument(MethodParameter methodParameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) {
+
+    Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+    int pageSize = pageable.getPageSize();
+    int pageNumber = pageable.getPageNumber() == 0 ? 0 : pageable.getPageNumber() - 1;
+
+    if (!ALLOWED_PAGE_SIZES.contains(pageSize)) {
+      return PageRequest.of(pageNumber, DEFAULT_PAGE_SIZE, pageable.getSort());
+    }
+    return PageRequest.of(pageNumber, pageSize, pageable.getSort());
+  }
+}

--- a/common/src/main/java/com/common/response/PageResponse.java
+++ b/common/src/main/java/com/common/response/PageResponse.java
@@ -1,0 +1,28 @@
+package com.common.response;
+
+import java.util.List;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@Builder
+public record PageResponse<T>(
+    List<T> contents,
+    long totalElements,
+    int totalPages,
+    int pageNumber,
+    int pageSize
+) {
+
+  public static <T> PageResponse<T> from(Page<T> page) {
+    Pageable pageable = page.getPageable();
+
+    return PageResponse.<T>builder()
+        .contents(page.getContent())
+        .totalElements(page.getTotalElements())
+        .totalPages(page.getTotalPages())
+        .pageNumber(pageable.getPageNumber() + 1)
+        .pageSize(pageable.getPageSize())
+        .build();
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #42 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**(변경 후 설명을 여기에 작성)
  - [x] 페이지 사이즈 10, 30, 50 제한
  - [x] 공통 페이지 응답 dto 추가
  - [x] page 속성(페이지넘버) 1부터 시작하도록 수정 (jpa default 0부터 시작)

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- page 속성(페이지넘버)를 1부터 시작하도록 수정 (jpa default 0부터 시작)
  - jpa는 페이지넘버를 0 부터 시작하도록 합니다.
    - `@PageableDefault` 어노테이션 활용시에도 page 속성(페이지넘버)의 default 값은 0으로 설정되어 있습니다.
  - 위 설정을 수정하여, 페이지 넘버가 1부터 시작할 수 있도록 PageagbleArgumentResolver 와 PageResponse 의 page 속성(페이지넘버) 값에 -1, +1 을 수행하도록 처리하였습니다.
- contents 속성으로 결과 응답값이 전달되므로, 팀원분들 각자 api 명세서에 해당하는 부분의 수정이 필요할 것 같습니다.
  
  