### PR TITLE
[common] AuthCheck NullpointerException 해결

### DIFF
--- a/common/src/main/java/com/common/aop/AuthCheckAspect.java
+++ b/common/src/main/java/com/common/aop/AuthCheckAspect.java
@@ -38,8 +38,12 @@ public class AuthCheckAspect {
     if (attributes == null) {
       throw CustomException.from(ApiErrorCode.UNAUTHORIZED);
     }
+
     HttpServletRequest request = attributes.getRequest();
     String userRoleStr = request.getHeader("X-User-Role");
+    if (userRoleStr == null) {
+      throw CustomException.from(ApiErrorCode.UNAUTHORIZED);
+    }
     return UserRole.valueOf(userRoleStr);
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #59

## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - Given: 헤더의 X-User-Role 값이 없는 경우
  - When: AuthCheck aop 코드 동작시, 헤더의 X-User-Role 값을 이넘으로 변환하는 과정에서
  - Then: NullpointerException 발생

- **to-be**
  - [x] 헤더의 X-User-Role 값이 없는 경우, NullpointerException 이 아닌 CustomException, 401 발생

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트