### PR TITLE
[gateway] 인증/인가 구현

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -28,18 +28,29 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+    implementation project(':common')
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-    // jjwt 0.12.6
+    runtimeOnly 'org.postgresql:postgresql'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // jwt
     implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // Jakarta Servlet API 추가
+    implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
 }
 

--- a/gateway/src/main/java/com/faster/gateway/app/global/config/SecurityConfig.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.faster.gateway.app.global.config;
+
+import com.faster.gateway.app.global.security.handler.ExceptionHandlingFilter;
+import com.faster.gateway.app.global.security.jwt.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UserDetailsRepositoryReactiveAuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+
+@Configuration
+@EnableReactiveMethodSecurity
+@EnableWebFluxSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final ExceptionHandlingFilter exceptionHandlingFilter;
+  private final JwtAuthenticationFilter authenticationFilter;
+  private final ReactiveUserDetailsService userDetailsService;
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityWebFilterChain securityFilterChain(ServerHttpSecurity http) {
+    http
+        .formLogin(form -> form.disable())
+        .logout(logout -> logout.disable())
+        .httpBasic(basicSpec -> basicSpec.disable())
+        .csrf(csrf -> csrf.disable())
+        .securityContextRepository(NoOpServerSecurityContextRepository.getInstance()) // 세션을 비활성화
+        .authorizeExchange(authorize -> authorize
+            .pathMatchers("/api/auth/**",
+                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+            .anyExchange().authenticated()
+        )
+        .addFilterAt(this.authenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)
+        .addFilterAt(this.exceptionHandlingFilter, SecurityWebFiltersOrder.FORM_LOGIN);
+
+    return http.build();
+  }
+
+  @Bean
+  public ReactiveAuthenticationManager authenticationManager() {
+    UserDetailsRepositoryReactiveAuthenticationManager authenticationManager =
+        new UserDetailsRepositoryReactiveAuthenticationManager(userDetailsService);
+    authenticationManager.setPasswordEncoder(passwordEncoder());
+    return authenticationManager;
+  }
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/config/WebFluxConfig.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/config/WebFluxConfig.java
@@ -1,0 +1,10 @@
+package com.faster.gateway.app.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.config.EnableWebFlux;
+
+@Configuration
+@EnableWebFlux
+public class WebFluxConfig {
+
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/exception/GatewayErrorCode.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/exception/GatewayErrorCode.java
@@ -1,0 +1,27 @@
+package com.faster.gateway.app.global.exception;
+
+import com.common.exception.type.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatewayErrorCode implements ErrorCode {
+
+  // Unauthorized: 401 - 인증 이슈
+  INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 JWT 서명입니다.", HttpStatus.UNAUTHORIZED),
+  EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED.value(), "만료된 JWT token 입니다.", HttpStatus.UNAUTHORIZED),
+  UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED.value(), "지원되지 않는 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
+  JWT_CLAIMS_EMPTY(HttpStatus.UNAUTHORIZED.value(), "잘못된 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
+
+  // Not Found: 404 - 자원 없음
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "유저 개체를 찾지 못했습니다.", HttpStatus.NOT_FOUND),
+
+  // Internal Server Error: 500 - 서버 문제 발생
+  BAD_PADDING(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 패딩입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final int code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/filter/UserInfoFilter.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/filter/UserInfoFilter.java
@@ -1,0 +1,51 @@
+package com.faster.gateway.app.global.filter;
+
+import com.faster.gateway.app.global.security.service.dto.CustomUserDetails;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public class UserInfoFilter implements GlobalFilter {
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    Mono<SecurityContext> context = ReactiveSecurityContextHolder.getContext();
+
+    return context
+        .flatMap(securityContext -> {
+          Authentication authentication = securityContext.getAuthentication();
+          Object principal = authentication.getPrincipal();
+          Long userId = null;
+          String userRole = null;
+
+          if (principal instanceof CustomUserDetails) {
+            CustomUserDetails userDetails = (CustomUserDetails) principal;
+            userId = userDetails.getMemberId();
+            userRole = userDetails.getAuthorities().iterator().next().getAuthority();
+          }
+
+          if (userId != null) {
+            ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
+                .header("X-User-Id", String.valueOf(userId))
+                .header("X-User-Role", userRole)
+                .build();
+
+            // 새로운 요청을 포함하는 exchange를 생성
+            ServerWebExchange modifiedExchange = exchange.mutate().request(modifiedRequest).build();
+
+            return chain.filter(modifiedExchange);
+          }
+
+          return chain.filter(exchange);
+        })
+        .switchIfEmpty(chain.filter(exchange));
+  }
+}
+

--- a/gateway/src/main/java/com/faster/gateway/app/global/security/handler/ExceptionHandlingFilter.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/security/handler/ExceptionHandlingFilter.java
@@ -1,0 +1,43 @@
+package com.faster.gateway.app.global.security.handler;
+
+import com.common.exception.CustomException;
+import com.common.exception.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class ExceptionHandlingFilter implements WebFilter {
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    try {
+      return chain.filter(exchange);
+    } catch (CustomException e) {
+      log.error(e.getMessage());
+      ErrorResponse exceptionResponse = ErrorResponse.of(e.getErrorCode().getStatus(), e);
+      ServerHttpResponse response = exchange.getResponse();
+      response.setStatusCode(e.getErrorCode().getStatus());
+      response.getHeaders().setContentType(MediaType.valueOf(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8"));
+      byte[] bytes = null;
+      try {
+        bytes = objectMapper.writeValueAsBytes(exceptionResponse);
+      } catch (JsonProcessingException ex) {
+        throw new RuntimeException(ex);
+      }
+      return response.writeWith(
+          Mono.just(exchange.getResponse().bufferFactory().wrap(bytes)));
+    }
+  }
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package com.faster.gateway.app.global.security.jwt.filter;
+
+import com.faster.gateway.app.global.security.jwt.util.TokenProvider;
+import jakarta.ws.rs.core.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements WebFilter {
+
+  private final TokenProvider tokenProvider;
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    String accessToken = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+    log.info("[JwtAuthenticationFilter]{}", accessToken);
+
+    if (tokenProvider.validAccessToken(accessToken)) {
+      return tokenProvider.getAuthentication(accessToken)
+          .flatMap(authentication ->
+              chain.filter(exchange)
+                  .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication)))
+          ;
+    } else {
+      return chain.filter(exchange); // 토큰이 유효하지 않은 경우 인증을 설정하지 않고 요청을 계속 진행
+    }
+  }
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/security/jwt/util/TokenProvider.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/security/jwt/util/TokenProvider.java
@@ -1,0 +1,97 @@
+package com.faster.gateway.app.global.security.jwt.util;
+
+import com.common.exception.CustomException;
+import com.faster.gateway.app.global.exception.GatewayErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TokenProvider {
+
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  private final ReactiveUserDetailsService userDetailsService;
+
+  private SecretKey key;
+  @Value("${jwt.secret}")
+  private String secretKey;
+
+  public Mono<Authentication> getAuthentication(String token) {
+    if (!StringUtils.hasText(token) || !token.startsWith(TOKEN_PREFIX)) {
+      return null;
+    }
+    token = token.substring(TOKEN_PREFIX.length());
+    return this.userDetailsService.findByUsername(this.getUsername(token))
+        .map(userDetails -> {
+          // UsernamePasswordAuthenticationToken을 생성하고 반환한다
+          return new UsernamePasswordAuthenticationToken(
+              userDetails,
+              null,  // 비밀번호는 null로 설정
+              userDetails.getAuthorities()
+          );
+        });
+  }
+
+  public boolean validAccessToken(String token) {
+    if (!StringUtils.hasText(token) || !token.startsWith(TOKEN_PREFIX)) {
+      return false;
+    }
+
+    return validateToken(token.substring(TOKEN_PREFIX.length()));
+  }
+
+  private boolean validateToken(String token) {
+    return !getExpiration(token).before(new Date());
+  }
+
+  private Date getExpiration(String token) {
+    if (!StringUtils.hasText(token)) {
+      throw CustomException.from(GatewayErrorCode.BAD_PADDING.EXPIRED_JWT_TOKEN);
+    }
+
+    return this.parseClaims(token).getExpiration();
+  }
+
+  private String getUsername(String token) {
+    return this.parseClaims(token).get("userId", String.class);
+  }
+
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+    } catch (SecurityException | MalformedJwtException | SignatureException e) {
+      throw CustomException.from(GatewayErrorCode.INVALID_JWT_SIGNATURE);
+    } catch (ExpiredJwtException e) {
+      throw CustomException.from(GatewayErrorCode.EXPIRED_JWT_TOKEN);
+    } catch (UnsupportedJwtException e) {
+      throw CustomException.from(GatewayErrorCode.UNSUPPORTED_JWT_TOKEN);
+    } catch (IllegalArgumentException e) {
+      throw CustomException.from(GatewayErrorCode.JWT_CLAIMS_EMPTY);
+    }
+  }
+
+  @PostConstruct
+  private void setKey() {
+    key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(this.secretKey));
+  }
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/security/service/CustomUserDetailsService.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/security/service/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.faster.gateway.app.global.security.service;
+
+import com.faster.gateway.app.global.security.service.dto.CustomUserDetails;
+import com.faster.gateway.app.global.security.service.dto.UserDetailsDto;
+import com.faster.gateway.app.global.exception.GatewayErrorCode;
+import com.faster.gateway.app.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements ReactiveUserDetailsService {
+  private final UserRepository userRepository;
+
+  @Override
+  public Mono<UserDetails> findByUsername(String username) {
+    return Mono.fromSupplier(() -> new CustomUserDetails(getUserDetailsDomain(username)));
+  }
+
+  private UserDetailsDto getUserDetailsDomain(String username) {
+    return UserDetailsDto.from(userRepository.findByUsername(username)
+        .orElseThrow(() -> new UsernameNotFoundException(
+            GatewayErrorCode.USER_NOT_FOUND.getMessage()
+        )));
+  }
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/security/service/dto/Authenticated.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/security/service/dto/Authenticated.java
@@ -1,0 +1,11 @@
+package com.faster.gateway.app.global.security.service.dto;
+
+
+import com.common.resolver.dto.UserRole;
+
+public interface Authenticated {
+  Long getId();
+  String getUsername();
+  String getPassword();
+  UserRole getRole();
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/security/service/dto/CustomUserDetails.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/security/service/dto/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package com.faster.gateway.app.global.security.service.dto;
+
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private final transient UserDetailsDto userDetailsDto;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return userDetailsDto.getAuthorities();
+  }
+
+  public Long getMemberId() {
+    return userDetailsDto.id();
+  }
+
+  @Override
+  public String getPassword() {
+    return userDetailsDto.password();
+  }
+
+  @Override
+  public String getUsername() {
+    return userDetailsDto.username();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+}

--- a/gateway/src/main/java/com/faster/gateway/app/global/security/service/dto/UserDetailsDto.java
+++ b/gateway/src/main/java/com/faster/gateway/app/global/security/service/dto/UserDetailsDto.java
@@ -1,0 +1,34 @@
+package com.faster.gateway.app.global.security.service.dto;
+
+import com.common.resolver.dto.UserRole;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public record UserDetailsDto(
+    Long id,
+
+    String username,
+
+    String password,
+
+    UserRole role
+
+) {
+
+  public static UserDetailsDto from(Authenticated user) {
+    return new UserDetailsDto(
+        user.getId(),
+        user.getUsername(),
+        user.getPassword(),
+        user.getRole()
+    );
+  }
+
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority(role.name()));
+    return authorities;
+  }
+}

--- a/gateway/src/main/java/com/faster/gateway/app/user/domain/entity/User.java
+++ b/gateway/src/main/java/com/faster/gateway/app/user/domain/entity/User.java
@@ -1,0 +1,41 @@
+package com.faster.gateway.app.user.domain.entity;
+
+import com.common.domain.BaseEntity;
+import com.common.resolver.dto.UserRole;
+import com.faster.gateway.app.global.security.service.dto.Authenticated;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity implements Authenticated {
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  @Column(name = "username", length = 100, nullable = false, unique = true)
+  private String username;
+
+  @Column(name = "password", length = 500, nullable = false)
+  private String password;
+
+  @Column(name = "name", length = 100, nullable = false)
+  private String name;
+
+  @Column(name = "slack_id", length = 200, nullable = false)
+  private String slackId;
+
+  @Enumerated(EnumType.STRING)
+  private UserRole role;
+}

--- a/gateway/src/main/java/com/faster/gateway/app/user/domain/repository/UserJpaRepository.java
+++ b/gateway/src/main/java/com/faster/gateway/app/user/domain/repository/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package com.faster.gateway.app.user.domain.repository;
+
+import com.faster.gateway.app.user.domain.entity.User;
+import com.faster.gateway.app.user.infrastructure.UserRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends UserRepository, JpaRepository<User, Long> {
+
+}

--- a/gateway/src/main/java/com/faster/gateway/app/user/infrastructure/UserRepository.java
+++ b/gateway/src/main/java/com/faster/gateway/app/user/infrastructure/UserRepository.java
@@ -1,0 +1,10 @@
+package com.faster.gateway.app.user.infrastructure;
+
+import com.faster.gateway.app.user.domain.entity.User;
+import java.util.Optional;
+
+public interface UserRepository {
+
+  Optional<User> findByUsername(String username);
+
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,66 +1,25 @@
-server:
-  port: 15010
-
 spring:
-  main:
-    web-application-type: reactive
   application:
     name: gateway-service
-  cloud:
-    gateway:
-      routes:
-        # 배송
-        - id: delivery-service
-          uri: lb://delivery-service
-          predicates:
-            - Path=/api/deliveries/**
-        # 배송담당자
-        - id: delivery-manager-service
-          uri: lb://delivery-manager-service
-          predicates:
-            - Path=/api/delivery-managers/**
-        # 회원
-        - id: user-service
-          uri: lb://user-service
-          predicates:
-            - Path=/api/auth/**
-            - Path=/api/users/**
-        # 메시지
-        - id: message-service
-          uri: lb://message-service
-          predicates:
-            - Path=/api/messages/**
-        # 결제
-        - id: payment-service
-          uri: lb://payment-service
-          predicates:
-            - Path=/api/payments/**
-        # 상품
-        - id: product-service
-          uri: lb://product-service
-          predicates:
-            - Path=/api/products/**
-        # 업체
-        - id: company-service
-          uri: lb://company-service
-          predicates:
-            - Path=/api/companies/**
-        # 주문
-        - id: order-service
-          uri: lb://order-service
-          predicates:
-            - Path=/api/orders/**
-        # 허브
-        - id: hub-service
-          uri: lb://hub-service
-          predicates:
-            - Path=/api/hubs/**
-      discovery:
-        locator:
-          enabled: true
+  config:
+    import:
+      - file:.env.gateway[.properties]
+      - classpath:/properties/base.yml
+      - classpath:/properties/datasource.yml
+      - classpath:/properties/jpa.yml
+      - classpath:/properties/cloud.yml
+      - classpath:/properties/gateway-route.yml
+      - classpath:/properties/jwt.yml
+  profiles:
+    group:
+      local: local
+      test: test
+      prod: prod
+    active: local
 
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:8761/eureka/
+
+
+
+
+
 

--- a/gateway/src/main/resources/properties/base.yml
+++ b/gateway/src/main/resources/properties/base.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8080

--- a/gateway/src/main/resources/properties/cloud.yml
+++ b/gateway/src/main/resources/properties/cloud.yml
@@ -1,0 +1,4 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/

--- a/gateway/src/main/resources/properties/datasource.yml
+++ b/gateway/src/main/resources/properties/datasource.yml
@@ -1,0 +1,14 @@
+# local 환경
+spring:
+  config.activate.on-profile: local
+  datasource:
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      schema: faster
+#  sql:
+#    init:
+#      mode: always
+#      data-locations: classpath:db/data.sql # db 시작할때 실행시킬 script (더미 데이터 생성)

--- a/gateway/src/main/resources/properties/gateway-route.yml
+++ b/gateway/src/main/resources/properties/gateway-route.yml
@@ -1,0 +1,58 @@
+spring:
+  main:
+    web-application-type: reactive
+  cloud:
+    gateway:
+      routes:
+        # 배송
+        - id: delivery-service
+          uri: lb://delivery-service
+          predicates:
+            - Path=/api/deliveries/**
+        # 배송담당자
+        - id: delivery-service
+          uri: lb://delivery-service
+          predicates:
+            - Path=/api/delivery-managers/**
+        # 회원
+        - id: user-service
+          uri: lb://user-service
+          predicates:
+            - Path=/api/auth/**
+        - id: user-service
+          uri: lb://user-service
+          predicates:
+            - Path=/api/users/**
+        # 메시지
+        - id: message-service
+          uri: lb://message-service
+          predicates:
+            - Path=/api/messages/**
+        # 결제
+        - id: payment-service
+          uri: lb://payment-service
+          predicates:
+            - Path=/api/payments/**
+        # 상품
+        - id: product-service
+          uri: lb://product-service
+          predicates:
+            - Path=/api/products/**
+        # 업체
+        - id: company-service
+          uri: lb://company-service
+          predicates:
+            - Path=/api/companies/**
+        # 주문
+        - id: order-service
+          uri: lb://order-service
+          predicates:
+            - Path=/api/orders/**
+        # 허브
+        - id: hub-service
+          uri: lb://hub-service
+          predicates:
+            - Path=/api/hubs/**
+      discovery:
+        locator:
+          enabled: true

--- a/gateway/src/main/resources/properties/jpa.yml
+++ b/gateway/src/main/resources/properties/jpa.yml
@@ -1,0 +1,15 @@
+# local 환경
+spring:
+  config.activate.on-profile: local
+  jpa:
+    database: postgresql
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+    #      default_batch_fetch_size: 10
+    generate-ddl: true
+#    defer-datasource-initialization: true # hibernate가 초기화되기 전 data.sql 실행하는 것을 방지

--- a/gateway/src/main/resources/properties/jwt.yml
+++ b/gateway/src/main/resources/properties/jwt.yml
@@ -1,0 +1,2 @@
+jwt:
+  secret: ${SECRET_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #66

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 인증 인가 구현 전

- **to-be**

  - [x] 인증인가 게이트웨이에서 처리
  - [x] filter에서 회원 정보 헤더에 추가

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- 로그인, 회원가입: 게이트웨이 -> 유저서비스
- 토큰을 통한 인증인가: 게이트웨이에서 진행
  - jwt에 필요한 정보(USER_ID, USER_ROLE)를 헤더에 담아 각 서비스에 전달
- 서비스간 통신: 게이트웨이에서 받아온 헤더 정보를 유지하여 처리

각 서비스에서 개별적으로 인증/인가를 수행할지 고민했지만, 이 경우 모든 서비스가 유저 서비스와 직접 통신해야 하므로 비효율적이라고 판단했습니다.
또한, 각 서비스의 IP 주소 유출 가능성에 대한 우려는 네트워크 단에서의 프라이빗 처리와 서브넷 마스크 등의 보안 조치를 통해 작업이 이루어지고,
이를 바탕으로 모든 요청이 반드시 게이트웨이를 거치도록 보안이 적용된 상태라는 전제하에 진행할 예정입니다.