### PR TITLE
[auth] 액세스 토큰 안에 회원 ID ,권한 포함

### DIFF
--- a/user/src/main/java/com/faster/user/app/auth/application/usecase/AuthServiceImpl.java
+++ b/user/src/main/java/com/faster/user/app/auth/application/usecase/AuthServiceImpl.java
@@ -73,7 +73,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole());
-    String refreshToken = jwtProvider.createRefreshToken(requestDto.username());
+    String refreshToken = jwtProvider.createRefreshToken(user.getId());
 
     return SignInUserResponseDto.of(accessToken, refreshToken, user.getId(), user.getRole().name());
   }

--- a/user/src/main/java/com/faster/user/app/auth/application/usecase/AuthServiceImpl.java
+++ b/user/src/main/java/com/faster/user/app/auth/application/usecase/AuthServiceImpl.java
@@ -72,7 +72,7 @@ public class AuthServiceImpl implements AuthService {
       throw new CustomException(SIGN_IN_INVALID_USERNAME);
     }
 
-    String accessToken = jwtProvider.createAccessToken(requestDto.username());
+    String accessToken = jwtProvider.createAccessToken(user.getId(), user.getRole());
     String refreshToken = jwtProvider.createRefreshToken(requestDto.username());
 
     return SignInUserResponseDto.of(accessToken, refreshToken, user.getId(), user.getRole().name());

--- a/user/src/main/java/com/faster/user/app/auth/jwt/JwtProvider.java
+++ b/user/src/main/java/com/faster/user/app/auth/jwt/JwtProvider.java
@@ -47,7 +47,7 @@ public class JwtProvider {
         .compact();
   }
 
-  public String createRefreshToken(String id) {
+  public String createRefreshToken(Long id) {
     return Jwts.builder()
         .claim("userId", id)
         .issuer(issuer)

--- a/user/src/main/java/com/faster/user/app/auth/jwt/JwtProvider.java
+++ b/user/src/main/java/com/faster/user/app/auth/jwt/JwtProvider.java
@@ -1,16 +1,18 @@
 package com.faster.user.app.auth.jwt;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import com.common.resolver.dto.UserRole;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Date;
 import javax.crypto.SecretKey;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Getter
 @Component
 public class JwtProvider {
 
@@ -34,12 +36,13 @@ public class JwtProvider {
     this.secretKey = Keys.hmacShaKeyFor(keyBytes);
   }
 
-  public String createAccessToken(String id) {
+  public String createAccessToken(Long id, UserRole role) {
     return Jwts.builder()
         .claim("userId", id)
+        .claim("userRole", role)
         .issuer(issuer)
         .issuedAt(new Date(System.currentTimeMillis()))
-        .expiration(new Date(System.currentTimeMillis()+ accessTokenExpiration))
+        .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
         .signWith(secretKey)
         .compact();
   }
@@ -49,7 +52,7 @@ public class JwtProvider {
         .claim("userId", id)
         .issuer(issuer)
         .issuedAt(new Date(System.currentTimeMillis()))
-        .expiration(new Date(System.currentTimeMillis()+ refreshTokenExpiration))
+        .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
         .signWith(secretKey)
         .compact();
   }
@@ -67,14 +70,23 @@ public class JwtProvider {
     }
   }
 
-
-  public String getUserIdFromToken(String token) {
+  public UserRole getUserIdFromToken(String token) {
     Claims claims = Jwts.parser()
         .verifyWith(secretKey)
         .build()
         .parseSignedClaims(token)
         .getPayload();
-    return claims.get("userId", String.class);
+    return claims.get("userId", UserRole.class);
+  }
+
+
+  public String getUserRoleFromToken(String token) {
+    Claims claims = Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+    return claims.get("userRole", String.class);
   }
 
 }


### PR DESCRIPTION
토큰 안에 회원 고유 식별 번호와 권한을 추가한다.

## #️⃣연관된 이슈
- 이슈 번호: #108 

## 변경 타입
- [x] 리팩토링

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)
액세스 토큰 클레임 안에 id 만 존재

- **to-be**(변경 후 설명을 여기에 작성)

  - [x] TODO 액세스 토큰 안에 id, 권한을 포함하도록 수정

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)