### PR TITLE
[user, message, delivery] 주문 openfeign 조회 실패 리팩토링

### DIFF
--- a/delivery/src/main/java/com/faster/delivery/app/delivery/application/usecase/DeliveryServiceImpl.java
+++ b/delivery/src/main/java/com/faster/delivery/app/delivery/application/usecase/DeliveryServiceImpl.java
@@ -106,9 +106,9 @@ public class DeliveryServiceImpl implements DeliveryService {
 
     List<HubDto> hubListData = hubClient.getHubListData(routeIds);
 
-//    sendMessage(hubListData,
-//        deliverySaveDto.sourceHubId(), deliverySaveDto.destinationHubId(),
-//        savedDelivery, deliveryManagerDto.deliveryManagers());
+    sendMessage(hubListData,
+        deliverySaveDto.sourceHubId(), deliverySaveDto.destinationHubId(),
+        savedDelivery, deliveryManagerDto.deliveryManagers());
 
     // TODO : 허브 배송 기사 배정 로직 구현
 
@@ -235,8 +235,8 @@ public class DeliveryServiceImpl implements DeliveryService {
 
     List<HubDto> hubListData = hubClient.getHubListData(routeIds);
 
-//    sendMessage(hubListData, supplierCompany.hubId(), receiveCompany.hubId(),
-//        savedDelivery, List.of(deliveryManagerDto.deliveryManagers().get(0)));
+    sendMessage(hubListData, supplierCompany.hubId(), receiveCompany.hubId(),
+        savedDelivery, List.of(deliveryManagerDto.deliveryManagers().get(0)));
 
     return savedDelivery.getId();
   }

--- a/message/src/main/java/com/faster/message/app/global/feign/FeignClientConfig.java
+++ b/message/src/main/java/com/faster/message/app/global/feign/FeignClientConfig.java
@@ -1,0 +1,35 @@
+package com.faster.message.app.global.feign;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+@EnableFeignClients
+public class FeignClientConfig {
+
+  private static final String USER_ID_HEADER_NAME = "X-User-Id";
+  private static final String USER_ROLE_HEADER_NAME = "X-User-Role";
+
+  @Bean
+  public RequestInterceptor requestInterceptor() {
+    return requestTemplate -> {
+      ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+      if (null != attributes) {
+        HttpServletRequest request = attributes.getRequest();
+        String userId = request.getHeader(USER_ID_HEADER_NAME);
+        String role = request.getHeader(USER_ROLE_HEADER_NAME);
+        if (userId != null) {
+          requestTemplate.header(USER_ID_HEADER_NAME, userId);
+        }
+        if (role != null) {
+          requestTemplate.header(USER_ROLE_HEADER_NAME, role);
+        }
+      }
+    };
+  }
+}

--- a/message/src/main/java/com/faster/message/app/global/feign/FeignClientErrorDecoder.java
+++ b/message/src/main/java/com/faster/message/app/global/feign/FeignClientErrorDecoder.java
@@ -1,0 +1,94 @@
+package com.faster.message.app.global.feign;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+
+import com.common.exception.CustomException;
+import com.common.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Request;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StreamUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration
+public class FeignClientErrorDecoder {
+
+  private final ObjectMapper objectMapper;
+
+  @Bean
+  public ErrorDecoder decoder() {
+
+    return (methodKey, response) -> {
+      ErrorResponse errorResponse = extractError(response);
+      loggingError(methodKey, response, errorResponse);
+
+      throw new CustomException(
+          HttpStatus.valueOf(response.status()),
+          errorResponse.code(),
+          errorResponse.message()
+      );
+    };
+  }
+
+  private ErrorResponse extractError(Response response) {
+    try (InputStream responseBodyStream = response.body().asInputStream()) {
+      String body = StreamUtils.copyToString(responseBodyStream, StandardCharsets.UTF_8);
+      return objectMapper.readValue(body, ErrorResponse.class);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void loggingError(String methodKey, Response response, ErrorResponse errorResponse) {
+    Request request = response.request();
+
+    log.error(""" 
+				\s
+				    Request Fail: {}
+				    URL: {} {}
+				    Status: {}
+				    Request Header: {}
+				    Request Body: {}
+				    Response Body: {}
+				\s""",
+        methodKey,
+        request.httpMethod(),
+        request.url(),
+        response.status(),
+        extractRequestHeader(request),
+        extractRequestBody(request),
+        errorResponse
+    );
+  }
+
+  private static String extractRequestHeader(Request request) {
+    Map<String, Collection<String>> headers = request.headers();
+
+    if (Objects.nonNull(headers)) {
+      return headers.toString();
+    }
+    return EMPTY;
+  }
+
+  private static String extractRequestBody(Request request) {
+    byte[] body = request.body();
+
+    if (Objects.nonNull(body)) {
+      new String(body, StandardCharsets.UTF_8);
+    }
+    return EMPTY;
+  }
+}

--- a/message/src/main/java/com/faster/message/app/global/filter/LoggingFilter.java
+++ b/message/src/main/java/com/faster/message/app/global/filter/LoggingFilter.java
@@ -1,0 +1,104 @@
+package com.faster.message.app.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Slf4j
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws
+		ServletException, IOException {
+
+		ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
+		ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
+
+		long start = System.currentTimeMillis();
+		filterChain.doFilter(requestWrapper, responseWrapper);
+		long end = System.currentTimeMillis();
+		LoggingData.of(requestWrapper, responseWrapper, (end - start) / 1000.0)
+			.toPrettyLog();
+
+		responseWrapper.copyBodyToResponse();
+	}
+
+	record LoggingData(
+		String requestUri,
+		String method,
+		int status,
+		Map<String, String> headers,
+		Map<String, String> queryString,
+		String requestBody,
+		String responseBody,
+		double elapsedTime
+	) {
+
+		static LoggingData of(ContentCachingRequestWrapper requestWrapper,
+			ContentCachingResponseWrapper responseWrapper, double elapsedTime) {
+			return new LoggingData(
+				requestWrapper.getRequestURI(),
+				requestWrapper.getMethod(),
+				responseWrapper.getStatus(),
+				getHeaders(requestWrapper),
+				getQueryParameter(requestWrapper),
+				contentBody(requestWrapper.getContentAsByteArray()),
+				contentBody(responseWrapper.getContentAsByteArray()),
+				elapsedTime);
+		}
+
+		private static Map<String, String> getHeaders(HttpServletRequest request) {
+			Map<String, String> headerMap = new HashMap<>();
+
+			Enumeration<String> headerArray = request.getHeaderNames();
+			while (headerArray.hasMoreElements()) {
+				String headerName = headerArray.nextElement();
+				headerMap.put(headerName, request.getHeader(headerName));
+			}
+			return headerMap;
+		}
+
+		private static Map<String, String> getQueryParameter(HttpServletRequest request) {
+			Map<String, String> queryMap = new HashMap<>();
+			request.getParameterMap()
+				.forEach((key, values) -> queryMap.put(key, String.join(";", values)));
+			return queryMap;
+		}
+
+		private static String contentBody(final byte[] contents) {
+			return new String(contents);
+		}
+
+		private void toPrettyLog() {
+
+			log.info("""
+					     
+					:::: METHOD: {}, URI: {}, STATUS: {} ::::
+					> Headers: {}
+					> QueryString: {}
+					> Request Body: {}
+					> Response Body: {}
+					> Elapsed Time: {}
+					""",
+				method,
+				requestUri,
+				status,
+				headers,
+				queryString,
+				requestBody,
+				responseBody,
+				elapsedTime);
+		}
+	}
+}

--- a/message/src/main/java/com/faster/message/app/message/application/dto/response/ASaveMessageResponseDto.java
+++ b/message/src/main/java/com/faster/message/app/message/application/dto/response/ASaveMessageResponseDto.java
@@ -19,9 +19,9 @@ public record ASaveMessageResponseDto(
     String productName, // 제품 이름
     Integer productQuantity, // 제품 수량
 
-    String hubSource, // 출발지
-    String hubWaypoint, // 경유지
-    String hubDestination, // 목적지
+    String hubSourceName, // 출발지
+    String hubWaypointName, // 경유지
+    String hubDestinationName, // 목적지
 
     String deliveryManager, // 배송 담당자
     String deliveryManagerSlackId // 배송 담당자 슬랙 ID

--- a/message/src/main/java/com/faster/message/app/message/application/usecase/MessageServiceImpl.java
+++ b/message/src/main/java/com/faster/message/app/message/application/usecase/MessageServiceImpl.java
@@ -98,6 +98,7 @@ public class MessageServiceImpl implements MessageService {
     messageRepository.save(message);
 
     return ASaveMessageResponseDto.builder()
+        .deliveryId(requestDto.deliveryId())
         .orderId(requestDto.orderInfo().orderId())
         .orderUserName(requestDto.orderInfo().orderUserName())
         .orderUserSlackId(requestDto.orderInfo().orderUserSlackId())
@@ -110,8 +111,9 @@ public class MessageServiceImpl implements MessageService {
         .productName(orderInfo.orderItems().get(0).name())
         .productQuantity(orderInfo.orderItems().get(0).quantity())
 
-        .hubWaypoint(requestDto.hubWaypointName())
-        .hubDestination(requestDto.hubDestinationName())
+        .hubSourceName(requestDto.hubSourceName())
+        .hubWaypointName(requestDto.hubWaypointName())
+        .hubDestinationName(requestDto.hubDestinationName())
 
         .deliveryManager(requestDto.deliveryManagers().get(0).deliveryManagerName())
         .deliveryManagerSlackId(deliveryManagerInfo.slackId())

--- a/message/src/main/java/com/faster/message/app/message/infrastructure/fegin/OrderFeignClient.java
+++ b/message/src/main/java/com/faster/message/app/message/infrastructure/fegin/OrderFeignClient.java
@@ -1,6 +1,7 @@
 package com.faster.message.app.message.infrastructure.fegin;
 
 import com.common.response.ApiResponse;
+import com.faster.message.app.global.feign.FeignClientConfig;
 import com.faster.message.app.message.infrastructure.fegin.dto.response.IGetOrderResponseDto;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -8,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "order-service")
+@FeignClient(name = "order-service", configuration = FeignClientConfig.class)
 public interface OrderFeignClient {
 
   @GetMapping("/internal/orders/{orderId}")

--- a/message/src/main/java/com/faster/message/app/message/presentation/MessageInternalController.java
+++ b/message/src/main/java/com/faster/message/app/message/presentation/MessageInternalController.java
@@ -1,9 +1,17 @@
 package com.faster.message.app.message.presentation;
 
+import com.common.resolver.annotation.CurrentUserInfo;
+import com.common.resolver.dto.CurrentUserInfoDto;
 import com.common.response.ApiResponse;
 import com.common.response.PageResponse;
 import com.faster.message.app.global.response.MessageResponseCode;
+import com.faster.message.app.message.application.client.HubClient;
+import com.faster.message.app.message.application.client.OrderClient;
+import com.faster.message.app.message.application.client.UserClient;
 import com.faster.message.app.message.application.dto.request.ASaveMessageRequestDto;
+import com.faster.message.app.message.application.dto.response.AGetHubResponseDto;
+import com.faster.message.app.message.application.dto.response.AGetOrderResponseDto;
+import com.faster.message.app.message.application.dto.response.AGetUserResponseDto;
 import com.faster.message.app.message.application.dto.response.ASaveMessageResponseDto;
 import com.faster.message.app.message.application.usecase.MessageService;
 import com.faster.message.app.message.application.usecase.MessageServiceImpl;
@@ -11,6 +19,7 @@ import com.faster.message.app.message.presentation.dto.request.PSaveMessageReque
 import com.faster.message.app.message.presentation.dto.response.PGetAllMessageResponseDto;
 import com.faster.message.app.message.presentation.dto.response.PSaveMessageResponseDto;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -32,6 +41,12 @@ public class MessageInternalController {
   private final MessageService messageService;
 
   private final MessageServiceImpl messageServiceImpl;
+
+
+  private final OrderClient orderClient;
+  private final HubClient hubClient;
+  private final UserClient userClient;
+
 
 
   @PostMapping
@@ -73,8 +88,8 @@ public class MessageInternalController {
         .orderUserName(aSaveMessageResponseDto.orderUserName())
         .orderUserSlackId(aSaveMessageResponseDto.orderUserSlackId())
         .messageContent(aSaveMessageResponseDto.messageContent())
-        .hubWaypointName(aSaveMessageResponseDto.hubWaypoint())
-        .hubDestinationName(aSaveMessageResponseDto.hubDestination())
+        .hubWaypointName(aSaveMessageResponseDto.hubWaypointName())
+        .hubDestinationName(aSaveMessageResponseDto.hubDestinationName())
         .deliveryManagerName(aSaveMessageResponseDto.deliveryManager())
         .build();
 
@@ -132,4 +147,34 @@ public class MessageInternalController {
         responseDto
     ));
   }
+
+
+  @GetMapping("/order")
+  public ResponseEntity<AGetOrderResponseDto> getOrder(
+      @RequestParam UUID orderId
+  ) {
+    AGetOrderResponseDto orderByOrderId = orderClient.getOrderByOrderId(orderId);
+
+    return ResponseEntity.ok(orderByOrderId);
+  }
+
+
+  @GetMapping("/hub")
+  public ResponseEntity<AGetHubResponseDto> getHub(
+      @RequestParam List<UUID> hubId
+  ) {
+    AGetHubResponseDto orderByOrderId = hubClient.getOrderByOrderId(hubId);
+
+    return ResponseEntity.ok(orderByOrderId);
+  }
+
+  @GetMapping("/user")
+  public ResponseEntity<AGetUserResponseDto> getUser(
+      @RequestParam Long userId
+  ) {
+    AGetUserResponseDto userByUserId = userClient.getUserByUserId(userId);
+
+    return ResponseEntity.ok(userByUserId);
+  }
+
 }

--- a/message/src/main/resources/application.yml
+++ b/message/src/main/resources/application.yml
@@ -23,6 +23,11 @@ spring:
         show_sql: true
         format_sql: true
         use_sql_comments: ture
+        default_schema: faster
+    database: postgresql
+
+
+
 
 eureka:
   client:

--- a/user/src/main/java/com/faster/user/app/auth/config/RedisConfig.java
+++ b/user/src/main/java/com/faster/user/app/auth/config/RedisConfig.java
@@ -1,34 +1,45 @@
 package com.faster.user.app.auth.config;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-@RequiredArgsConstructor
-@EnableRedisRepositories
 @Configuration
 public class RedisConfig {
+  @Value("${spring.data.redis.host}")
+  private String host;
 
-  private final RedisProperties redisProperties;
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Value("${spring.data.redis.password}")
+  private String password;
 
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+    redisStandaloneConfiguration.setHostName(host);
+    redisStandaloneConfiguration.setPort(port);
+    redisStandaloneConfiguration.setPassword(password);
+    LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+    return lettuceConnectionFactory;
   }
 
   @Bean
-  public RedisTemplate<String, Object> redisTemplate() {
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
     RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory);
+    // 직렬화 역직렬화
     redisTemplate.setKeySerializer(new StringRedisSerializer());
-    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+    redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
     return redisTemplate;
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #226 

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 리팩토링

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)
  - [ ] TODO message에서 openfeign 회원 정보 가져오도록 config 설정
  - [ ] TODO delivery에서 메시지 생성 실패 주석 해제
  - [ ] TODO user 에서 현행 redis로 연결 등록

## 체크리스트
- [ ] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

메시지 정상 동작을 확인 되면 메시지 컨트롤러 안의 불필요한 api는 모두 제거할 예정입니다.