### PR TITLE
[hub] feat: 외부 api 재시도 적용

### DIFF
--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.github.openfeign:feign-micrometer'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
+    implementation 'io.github.resilience4j:resilience4j-all'
 }
 
 dependencyManagement {

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     implementation 'io.github.openfeign:feign-micrometer'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
-    implementation 'io.github.resilience4j:resilience4j-all'
 }
 
 dependencyManagement {

--- a/hub/src/main/java/com/faster/hub/app/global/exception/NaverDirectionApiErrorCode.java
+++ b/hub/src/main/java/com/faster/hub/app/global/exception/NaverDirectionApiErrorCode.java
@@ -1,0 +1,17 @@
+package com.faster.hub.app.global.exception;
+
+import com.common.exception.type.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NaverDirectionApiErrorCode implements ErrorCode {
+
+  SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE.value(), "Naver api 서버가 일시적으로 사용 불가능한 상태입니다.", HttpStatus.SERVICE_UNAVAILABLE);
+
+  private final int code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/hub/src/main/java/com/faster/hub/app/hub/infrastructure/client/NaverDirectionsApiClientImpl.java
+++ b/hub/src/main/java/com/faster/hub/app/hub/infrastructure/client/NaverDirectionsApiClientImpl.java
@@ -1,18 +1,34 @@
 package com.faster.hub.app.hub.infrastructure.client;
 
+import com.common.exception.CustomException;
+import com.faster.hub.app.global.exception.NaverDirectionApiErrorCode;
 import com.faster.hub.app.hub.application.usecase.DirectionsApiClient;
 import com.faster.hub.app.hub.application.usecase.dto.response.DirectionsApiApplicationResponseDto;
 import com.faster.hub.app.hub.infrastructure.client.feign.NaverDirectionsApiFeignClient;
+import feign.FeignException;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class NaverDirectionsApiClientImpl implements DirectionsApiClient {
+
   private final NaverDirectionsApiFeignClient directionsApiFeignClient;
 
   @Override
+  @Retry(name = "simpleRetryConfig", fallbackMethod = "fallback")
   public DirectionsApiApplicationResponseDto getDrivingRoute(String start, String goal) {
     return directionsApiFeignClient.getDrivingRoute(start, goal).toApplicationDto();
   }
+
+  DirectionsApiApplicationResponseDto fallback(String start, String goal,
+      FeignException.FeignServerException e) {
+    log.error("FeignServerException:{}:start:{}:goal:{}", e.getMessage(), start, goal);
+    // 추후 재시도 이벤트 발생하도록 변경
+    throw new CustomException(NaverDirectionApiErrorCode.SERVICE_UNAVAILABLE);
+  }
+
 }

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
       - classpath:/properties/directions-api.yml
       - classpath:/properties/redis.yml
       - classpath:/properties/zipkin.yml
+      - classpath:/properties/resilience4j-retry.yml
   profiles:
     group:
       local: local

--- a/hub/src/main/resources/properties/resilience4j-retry.yml
+++ b/hub/src/main/resources/properties/resilience4j-retry.yml
@@ -1,0 +1,17 @@
+resilience4j:retry:
+  configs:
+    retry-aspect-order: 2 # 우선 순위
+    default:
+      maxAttempts: 3 # 재시도 횟수
+      waitDuration: 1000 # 재시도 간격
+      retryExceptions:   # retryExceptions 에 지정된 예외는 재시도
+        - feign.FeignException.ServiceUnavailable
+        - feign.FeignException.FeignServerException
+      ignoreExceptions:
+        - feign.FeignException.BadGateway
+        - feign.FeignException.NotImplemented
+        - feign.FeignException.FeignClientException
+        - com.common.exception.CustomException
+  instances:
+    simpleRetryConfig:
+      baseConfig: default


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #240

## 변경 타입
- [x] 신규 기능 추가/수정
- [x] 리팩토링

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)
  - [x] resilience4j의 retry 적용

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.
- [ ] 관련 테스트를 추가했습니다.
- [ ] 문서(코드, 주석, README 등)를 업데이트했습니다.

## 코멘트
총 시도 3번 확인
```java
import com.common.exception.CustomException;
import com.faster.hub.app.global.exception.NaverDirectionApiErrorCode;
import com.faster.hub.app.hub.application.usecase.DirectionsApiClient;
import com.faster.hub.app.hub.application.usecase.dto.response.DirectionsApiApplicationResponseDto;
import com.faster.hub.app.hub.infrastructure.client.feign.NaverDirectionsApiFeignClient;
import feign.FeignException;
import feign.Request;
import feign.Request.HttpMethod;
import feign.RequestTemplate;
import io.github.resilience4j.retry.annotation.Retry;
import java.nio.charset.StandardCharsets;
import java.util.List;
import java.util.Map;
import lombok.RequiredArgsConstructor;
import lombok.extern.slf4j.Slf4j;
import org.springframework.stereotype.Component;

@Component
@Slf4j
@RequiredArgsConstructor
public class NaverDirectionsApiClientImpl implements DirectionsApiClient {

  private final NaverDirectionsApiFeignClient directionsApiFeignClient;

  @Override
  @Retry(name = "simpleRetryConfig", fallbackMethod = "fallback")
  public DirectionsApiApplicationResponseDto getDrivingRoute(String start, String goal) {
    throw new FeignException.FeignServerException(
        500,
        "status 500 reading DirectionsApiFeignClient#getDrivingRoute(String,String)",
        Request.create(
            Request.HttpMethod.GET,
            "https://api.example.com/directions?start="+start+"&goal="+goal,
            Map.of("Accept", List.of("application/json")),
            null,
            new RequestTemplate()
        ),
        "{\"error\":\"Internal Server Error\"}".getBytes(StandardCharsets.UTF_8),
        null
    );
//    return directionsApiFeignClient.getDrivingRoute(start, goal).toApplicationDto();
  }

  DirectionsApiApplicationResponseDto fallback(String start, String goal,
      FeignException.FeignServerException e) {
    log.error("FeignServerException:{}:start:{}:goal:{}", e.getMessage(), start, goal);
    // 추후 재시도 이벤트 발생하도록 변경
    throw new CustomException(NaverDirectionApiErrorCode.SERVICE_UNAVAILABLE);
  }

}
```
처럼 임의로 Exception을 던져서 테스트 해보았습니다.
아래는 fallback 로그 입니다.
```
[2025-03-24 15:36:08:81720] ERROR 12896 --- [http-nio-12001-exec-1, , ] [com.faster.hub.app.hub.infrastructure.client.NaverDirectionsApiClientImpl.fallback:48] : c.f.h.a.h.i.c.NaverDirectionsApiClientImpl : FeignServerException:status 500 reading DirectionsApiFeignClient#getDrivingRoute(String,String):start:127.37219605393632,37.1903545669702:goal:126.86959905394286,37.64028567162047
[2025-03-24 15:36:08:81748] ERROR 12896 --- [http-nio-12001-exec-1, , ] [com.common.exception.GlobalErrorHandler.log:22] : c.c.e.GlobalErrorHandler : /api/hubs/hub-routes:503:CustomException:Naver api 서버가 일시적으로 사용 불가능한 상태입니다.
```